### PR TITLE
PR

### DIFF
--- a/share/old-version/share/termux/mirror
+++ b/share/old-version/share/termux/mirror
@@ -158,7 +158,7 @@ mirror_sources_station_download_speed_test() {
     SOURCE_MIRROR_STATION='mirrors.cloud.tencent.com/termux'
     download_termux_clang
     SOURCE_MIRROR_STATION_NAME='official'
-    SOURCE_MIRROR_STATION='packages.termux.org'
+    SOURCE_MIRROR_STATION='packages.termux.dev'
     download_termux_clang
     ###此处一定要将SOURCE_MIRROR_STATION赋值为空
     SOURCE_MIRROR_STATION=""

--- a/share/old-version/share/termux/mirror
+++ b/share/old-version/share/termux/mirror
@@ -86,7 +86,7 @@ worldwide_mirror_station() {
         POINTLESS_LIST="${PREFIX}/etc/apt/sources.list.d/pointless.list"
         [[ ! -s ${POINTLESS_LIST} ]] || do_you_want_to_continue
         cd ${TMPDIR}
-        curl -Lo .setup-pointless-repo.sh https://its-pointless.github.io/setup-pointless-repo.sh
+        aria2c --console-log-level=warn --no-conf --allow-overwrite=true -d ${TMPDIR} -o '.setup-pointless-repo.sh' 'https://raw.githubusercontent.com/2moe/tmoe/master/share/old-version/share/termux/setup-pointless-repo'
         if [ $(command -v bat) ]; then
             bat -ppn .setup-pointless-repo.sh
         else

--- a/share/old-version/share/termux/mirror
+++ b/share/old-version/share/termux/mirror
@@ -272,10 +272,9 @@ check_android_version() {
     ANDROID_6_FILE="${CONFIG_FOLDER}/android6_termux"
     if [ "${LINUX_DISTRO}" = 'Android' ] && [ ! -e "${ANDROID_6_FILE}" ]; then
         if (("${ANDROID_VERSION}" < 7)); then
-            printf "%s\n" "检测到您当前的安卓系统版本低于7,请勿使用本工具进行换源。" >${ANDROID_6_FILE}
+            printf "%s\n" "检测到您当前的安卓系统版本低于7,请使用官方Termux为低于安卓7版本构建的app：https://github.com/termux/termux-app/actions/runs/2237286563" >${ANDROID_6_FILE}
             sed -n p ${ANDROID_6_FILE}
-            printf "%s\n" "Your current Android system version is lower than 7."
-            printf "%s\n" "旧版Android可能无法使用本功能。"
+            printf "%s\n" "Your current Android system version is lower than 7,Please use the official Termux app built for versions lower than Android 7:https://github.com/termux/termux-app/actions/runs/2237286563"
             press_enter_to_continue
         fi
     fi

--- a/share/old-version/share/termux/setup-pointless-repo
+++ b/share/old-version/share/termux/setup-pointless-repo
@@ -1,0 +1,12 @@
+#!/data/data/com.termux/files/usr/bin/sh
+pkg up -y
+pkg upgr -y
+pkg i coreutils gnupg -y
+mkdir -p $PREFIX/etc/apt/sources.list.d
+ANDROID_VERSION=$(getprop ro.build.version.release)
+if [ "$ANDROID_VERSION" -ge "7" ]; then
+    echo "deb [trusted=yes] https://its-pointless.github.io/files/24 termux extras" > $PREFIX/etc/apt/sources.list.d/pointless.list
+else
+    echo "deb [trusted=yes] https://its-pointless.github.io/files/21 termux extras" > $PREFIX/etc/apt/sources.list.d/pointless.list
+fi
+pkg up -y


### PR DESCRIPTION
# 修复its-pointless

~~its准备跑路了~~  

https://github.com/its-pointless/gcc_termux/blob/811b270ee996439a16f453ff6b646b28dffdad04/setup-pointless-repo.sh#L9  

这个判断过时了  

# 更改`packages.termux.org`到`packages.termux.dev`

[Grimler91](https://github.com/orgs/termux/people)最近又买了个[termux.dev](https://termux.dev)

现在`packages.termux.org`会被重定向到`packages.termux.dev`  ，`packages-cf.termux.org`会被重定向到`packages-cf.termux.dev`

由于[fosshost的问题](https://github.com/termux/termux-packages/issues/11007)，运气不好可能会500😅  ，等Fosshost修复

# 更改低于安卓7的提示


https://github.com/termux/termux-app/pull/2740


# 关于换源的建议

~~把全部源砍掉~~，用官方的`termux-change-repo`

或者全部加上，或者挑一些速度快的（）

国内源：https://github.com/termux/termux-packages/wiki/Mirrors#mirrors-hosted-in-china

国内源就有14个（（（（（（